### PR TITLE
Refactor Python UI modules

### DIFF
--- a/src/main_python/chat_history.py
+++ b/src/main_python/chat_history.py
@@ -1,170 +1,183 @@
-# chat_history.py
+"""Chat history management utilities."""
+
+from __future__ import annotations
+
 import sqlite3
-import os
+from dataclasses import dataclass
 from datetime import datetime
-from typing import List, Dict, Optional, Any
-import json
 from pathlib import Path
+from typing import Iterable, List, Optional
+
+
+@dataclass
+class ChatMessage:
+    chat_id: str
+    role: str
+    content: str
+    timestamp: datetime | None = None
+
+
+@dataclass
+class Chat:
+    id: str
+    title: str
+    created_at: datetime | None = None
+
 
 class ChatHistory:
-    def __init__(self, db_path: str = None):
-        # Default to a local directory if no path is provided
+    """In-memory chat history used during a conversation."""
+
+    def __init__(self) -> None:
+        self._messages: List[ChatMessage] = []
+
+    def add(self, role: str, content: str) -> None:
+        self._messages.append(ChatMessage("", role, content, datetime.utcnow()))
+
+    def clear(self) -> None:
+        self._messages.clear()
+
+    def to_ollama(self) -> List[dict[str, str]]:
+        return [
+            {"role": msg.role, "content": msg.content} for msg in self._messages
+        ]
+
+    def __iter__(self) -> Iterable[ChatMessage]:
+        return iter(self._messages)
+
+
+class PersistentChatHistory:
+    """SQLite backed chat history storage."""
+
+    def __init__(self, db_path: Optional[str] = None) -> None:
         if db_path is None:
-            app_data = os.path.join(str(Path.home()), ".cobolt")
-            os.makedirs(app_data, exist_ok=True)
-            db_path = os.path.join(app_data, "chat_history.db")
-        
+            app_data = Path.home() / ".cobolt"
+            app_data.mkdir(parents=True, exist_ok=True)
+            db_path = str(app_data / "chat_history.db")
         self.db_path = db_path
         self._init_db()
 
-    def _get_connection(self):
-        """Create and return a new database connection"""
+    # ------------------------------------------------------------------
+    def _get_connection(self) -> sqlite3.Connection:
         conn = sqlite3.connect(self.db_path)
-        conn.row_factory = sqlite3.Row  # Access columns by name
+        conn.row_factory = sqlite3.Row
         return conn
 
-    def _init_db(self):
-        """Initialize the database with required tables"""
+    def _init_db(self) -> None:
         with self._get_connection() as conn:
-            cursor = conn.cursor()
-            
-            # Create chats table
-            cursor.execute('''
+            cur = conn.cursor()
+            cur.execute(
+                """
                 CREATE TABLE IF NOT EXISTS chats (
                     id TEXT PRIMARY KEY,
                     title TEXT NOT NULL,
                     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
                 )
-            ''')
-            
-            # Create chat_messages table
-            cursor.execute('''
+                """
+            )
+            cur.execute(
+                """
                 CREATE TABLE IF NOT EXISTS chat_messages (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     chat_id TEXT NOT NULL,
-                    role TEXT CHECK(role IN ('user', 'assistant', 'tool')) NOT NULL,
+                    role TEXT CHECK(role IN ('user','assistant','tool')) NOT NULL,
                     content TEXT NOT NULL,
                     timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
-                    FOREIGN KEY (chat_id) REFERENCES chats(id) ON DELETE CASCADE
+                    FOREIGN KEY(chat_id) REFERENCES chats(id) ON DELETE CASCADE
                 )
-            ''')
-            
-            # Create index for faster lookups
-            cursor.execute('CREATE INDEX IF NOT EXISTS idx_chat_messages_chat_id ON chat_messages(chat_id)')
-            conn.commit()
-
-    # Chat operations
-    def create_chat(self, chat_id: str = None, title: str = "New Chat") -> str:
-        """Create a new chat and return its ID"""
-        if chat_id is None:
-            import uuid
-            chat_id = str(uuid.uuid4())
-        
-        with self._get_connection() as conn:
-            cursor = conn.cursor()
-            cursor.execute(
-                "INSERT INTO chats (id, title) VALUES (?, ?)",
-                (chat_id, title)
+                """
+            )
+            cur.execute(
+                "CREATE INDEX IF NOT EXISTS idx_chat_messages_chat_id ON chat_messages(chat_id)"
             )
             conn.commit()
-        return chat_id
 
-    def get_chat(self, chat_id: str) -> Optional[Dict[str, Any]]:
-        """Get a chat by ID"""
+    # ------------------------------------------------------------------
+    def create_chat(self, chat_id: str, title: str = "New Chat") -> None:
         with self._get_connection() as conn:
-            cursor = conn.cursor()
-            cursor.execute("SELECT * FROM chats WHERE id = ?", (chat_id,))
-            row = cursor.fetchone()
-            return dict(row) if row else None
+            conn.execute(
+                "INSERT INTO chats (id, title) VALUES (?, ?)",
+                (chat_id, title),
+            )
+            conn.commit()
 
-    def get_recent_chats(self, limit: int = 20) -> List[Dict[str, Any]]:
-        """Get a list of recent chats"""
+    def get_chat(self, chat_id: str) -> Optional[Chat]:
         with self._get_connection() as conn:
-            cursor = conn.cursor()
-            cursor.execute("""
-                SELECT c.*, 
-                       (SELECT content FROM chat_messages 
-                        WHERE chat_id = c.id 
-                        ORDER BY timestamp DESC LIMIT 1) as last_message
+            row = conn.execute(
+                "SELECT id, title, created_at FROM chats WHERE id=?", (chat_id,)
+            ).fetchone()
+            if not row:
+                return None
+            return Chat(id=row["id"], title=row["title"], created_at=row["created_at"])
+
+    def update_chat_title(self, chat_id: str, title: str) -> None:
+        with self._get_connection() as conn:
+            conn.execute(
+                "UPDATE chats SET title=? WHERE id=?",
+                (title, chat_id),
+            )
+            conn.commit()
+
+    def delete_chat(self, chat_id: str) -> None:
+        with self._get_connection() as conn:
+            conn.execute("DELETE FROM chats WHERE id=?", (chat_id,))
+            conn.commit()
+
+    def get_recent_chats(self, limit: int = 20) -> List[Chat]:
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT c.id, c.title, c.created_at,
+                       (SELECT content FROM chat_messages WHERE chat_id=c.id ORDER BY timestamp DESC LIMIT 1) as last_message
                 FROM chats c
                 ORDER BY created_at DESC
                 LIMIT ?
-            """, (limit,))
-            return [dict(row) for row in cursor.fetchall()]
+                """,
+                (limit,),
+            ).fetchall()
+            chats = [
+                Chat(id=row["id"], title=row["title"], created_at=row["created_at"])
+                for row in rows
+            ]
+            return chats
 
-    def update_chat_title(self, chat_id: str, title: str) -> bool:
-        """Update a chat's title"""
+    def add_message(self, chat_id: str, role: str, content: str) -> None:
+        if role not in {"user", "assistant", "tool"}:
+            raise ValueError("Invalid role")
         with self._get_connection() as conn:
-            cursor = conn.cursor()
-            cursor.execute(
-                "UPDATE chats SET title = ? WHERE id = ?",
-                (title, chat_id)
+            conn.execute(
+                "INSERT INTO chat_messages (chat_id, role, content) VALUES (?, ?, ?)",
+                (chat_id, role, content),
             )
             conn.commit()
-            return cursor.rowcount > 0
 
-    def delete_chat(self, chat_id: str) -> bool:
-        """Delete a chat and all its messages"""
+    def get_messages(self, chat_id: str, limit: int = 100) -> List[ChatMessage]:
         with self._get_connection() as conn:
-            cursor = conn.cursor()
-            cursor.execute("DELETE FROM chats WHERE id = ?", (chat_id,))
-            conn.commit()
-            return cursor.rowcount > 0
-
-    # Message operations
-    def add_message(self, chat_id: str, role: str, content: str) -> int:
-        """Add a message to a chat"""
-        # Input validation
-        if not isinstance(chat_id, str) or not chat_id.strip():
-            raise ValueError("Invalid chat_id")
-        if role not in ['user', 'assistant', 'tool']:
-            raise ValueError("Invalid role. Must be 'user', 'assistant', or 'tool'")
-        if not isinstance(content, str):
-            raise ValueError("Content must be a string")
-            
-        try:
-            with self._get_connection() as conn:
-                cursor = conn.cursor()
-                cursor.execute(
-                    "INSERT INTO chat_messages (chat_id, role, content) VALUES (?, ?, ?)",
-                    (chat_id, role, content)
+            rows = conn.execute(
+                """
+                SELECT chat_id, role, content, timestamp
+                FROM chat_messages
+                WHERE chat_id=?
+                ORDER BY timestamp ASC
+                LIMIT ?
+                """,
+                (chat_id, limit),
+            ).fetchall()
+            return [
+                ChatMessage(
+                    chat_id=row["chat_id"],
+                    role=row["role"],
+                    content=row["content"],
+                    timestamp=row["timestamp"],
                 )
-                conn.commit()
-                return cursor.lastrowid
-        except sqlite3.Error as e:
-            print(f"Database error in add_message: {e}")
-            raise
+                for row in rows
+            ]
 
-    def get_messages(self, chat_id: str, limit: int = 100) -> List[Dict[str, Any]]:
-        """Get messages for a chat"""
-        if not isinstance(chat_id, str) or not chat_id.strip():
-            raise ValueError("Invalid chat_id")
-            
-        try:
-            with self._get_connection() as conn:
-                cursor = conn.cursor()
-                cursor.execute("""
-                    SELECT * FROM chat_messages 
-                    WHERE chat_id = ? 
-                    ORDER BY timestamp ASC
-                    LIMIT ?
-                """, (chat_id, limit))
-                return [dict(row) for row in cursor.fetchall()]
-        except sqlite3.Error as e:
-            print(f"Database error in get_messages: {e}")
-            return []
+    def clear_all(self) -> None:
+        with self._get_connection() as conn:
+            conn.execute("DELETE FROM chat_messages")
+            conn.execute("DELETE FROM chats")
+            conn.commit()
 
-    def clear_all(self):
-        """Clear all chats and messages"""
-        try:
-            with self._get_connection() as conn:
-                cursor = conn.cursor()
-                cursor.execute("DELETE FROM chat_messages")
-                cursor.execute("DELETE FROM chats")
-                conn.commit()
-        except sqlite3.Error as e:
-            print(f"Database error in clear_all: {e}")
-            raise
 
-# Singleton instance
-chat_history = ChatHistory()
+# Singleton instance for convenience
+persistent_chat_history = PersistentChatHistory()

--- a/src/main_python/ollama_client.py
+++ b/src/main_python/ollama_client.py
@@ -1,0 +1,42 @@
+"""Simple Ollama client wrapper with error handling."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+import ollama
+import requests
+
+
+class OllamaClient:
+    """Wrapper around the ``ollama`` package used by the UI."""
+
+    def __init__(self, base_url: str = "http://localhost:11434") -> None:
+        self.base_url = base_url
+        self.client = ollama.Client(host=base_url, timeout=30)
+
+    # ------------------------------------------------------------------
+    def get_models(self) -> List[Dict[str, str]]:
+        try:
+            response = requests.get(f"{self.base_url}/api/tags", timeout=10)
+            if response.status_code == 200:
+                data = response.json()
+                return data.get("models", [])
+        except Exception:
+            pass
+
+        response = self.client.list()
+        if hasattr(response, "models"):
+            return response.models
+        return response.get("models", [])
+
+    # ------------------------------------------------------------------
+    def chat_stream(self, model: str, messages: List[Dict[str, str]]) -> Iterable[str]:
+        if not model or not messages:
+            raise ValueError("model and messages are required")
+
+        response = self.client.chat(model=model, messages=messages, stream=True)
+        for chunk in response:
+            if "message" in chunk and "content" in chunk["message"]:
+                yield chunk["message"]["content"]
+

--- a/src/main_python/ollama_worker.py
+++ b/src/main_python/ollama_worker.py
@@ -1,0 +1,39 @@
+"""Worker thread used to call the Ollama API without blocking the UI."""
+
+from __future__ import annotations
+
+from PyQt6.QtCore import QThread, pyqtSignal
+
+from .ollama_client import OllamaClient
+
+
+class OllamaWorker(QThread):
+    response_received = pyqtSignal(str)
+    response_complete = pyqtSignal(str)
+    error_occurred = pyqtSignal(str)
+
+    def __init__(self, client: OllamaClient, model: str, messages: list) -> None:
+        super().__init__()
+        self.client = client
+        self.model = model
+        self.messages = messages
+        self._is_running = True
+        self._buffer = ""
+
+    def run(self) -> None:
+        try:
+            for chunk in self.client.chat_stream(self.model, self.messages):
+                if not self._is_running:
+                    break
+                self._buffer += chunk
+                self.response_received.emit(self._buffer)
+
+            if self._is_running:
+                self.response_complete.emit(self._buffer)
+        except Exception as exc:  # pragma: no cover - UI code
+            if self._is_running:
+                self.error_occurred.emit(str(exc))
+
+    def stop(self) -> None:
+        self._is_running = False
+        self.wait()


### PR DESCRIPTION
## Summary
- create a small module layout for the python prototype
- split Ollama client and worker into their own files
- rewrite chat history module to provide in-memory and persistent classes
- update UI code to use the new classes

## Testing
- `python -m py_compile src/main_python/chat_history.py`
- `python -m py_compile src/main_python/ollama_client.py`
- `python -m py_compile src/main_python/ollama_worker.py`
- `python -m py_compile src/main_python/cobolt_ui.py`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847a166cdac833196a7b9374fbe6c94